### PR TITLE
Fix JSON parsing. homepage & desc can be null

### DIFF
--- a/brewer_core/src/models.rs
+++ b/brewer_core/src/models.rs
@@ -63,8 +63,8 @@ pub mod formula {
         pub struct Formula {
             pub name: String,
             pub tap: String,
-            pub desc: String,
-            pub homepage: String,
+            pub desc: Option<String>,
+            pub homepage: Option<String>,
             pub caveats: Option<String>,
 
             pub build_dependencies: Vec<String>,
@@ -197,7 +197,7 @@ pub mod cask {
             pub desc: Option<String>,
             pub version: String,
             pub caveats: Option<String>,
-            pub homepage: String,
+            pub homepage: Option<String>,
 
             pub deprecated: bool,
             pub deprecation_reason: Option<String>,

--- a/brewer_term/src/cli.rs
+++ b/brewer_term/src/cli.rs
@@ -387,8 +387,10 @@ impl Info {
 
     pub fn handle_formula(&self, formula: &models::formula::Formula, installed: Option<&models::formula::installed::Formula>) -> anyhow::Result<()> {
         if self.open_homepage {
-            open::that_detached(&formula.base.homepage)?;
-            return Ok(());
+            if let Some(homepage) = &formula.base.homepage {
+                open::that_detached(homepage)?;
+                return Ok(());
+            }
         }
 
         let mut buf = BufWriter::new(std::io::stdout());
@@ -402,8 +404,10 @@ impl Info {
 
     pub fn handle_cask(&self, cask: &models::cask::Cask, installed: Option<&models::cask::installed::Cask>) -> anyhow::Result<()> {
         if self.open_homepage {
-            open::that_detached(&cask.base.homepage)?;
-            return Ok(());
+            if let Some(homepage) = &cask.base.homepage {
+                open::that_detached(homepage)?;
+                return Ok(());
+            }
         }
 
         let mut buf = BufWriter::new(std::io::stdout());
@@ -425,11 +429,15 @@ fn info_formula(mut buf: impl Write, formula: &models::formula::Formula, install
         writeln!(buf, "Installed {} {}", installed.receipt.source.version(), pretty::bool(true))?;
     }
 
+    if let Some(homepage) = &formula.base.homepage {
+        writeln!(buf)?;
+        writeln!(buf, "{}", homepage.underline().blue())?;
+    }
 
-    writeln!(buf)?;
-    writeln!(buf, "{}", formula.base.homepage.underline().blue())?;
-    writeln!(buf)?;
-    writeln!(buf, "{}", formula.base.desc.italic())?;
+    if let Some(desc) = &formula.base.desc {
+        writeln!(buf)?;
+        writeln!(buf, "{}", desc.italic())?;
+    }
 
     if !formula.executables.is_empty() {
         writeln!(buf)?;
@@ -469,9 +477,10 @@ fn info_cask(buf: &mut impl Write, cask: &models::cask::Cask, installed: Option<
         writeln!(buf)?;
     }
 
-    writeln!(buf, "{}", cask.base.homepage.underline().blue())?;
-    writeln!(buf)?;
-
+    if let Some(homepage) = &cask.base.homepage {
+        writeln!(buf, "{}", homepage.underline().blue())?;
+        writeln!(buf)?;
+    }
 
     let desc = if let Some(desc) = &cask.base.desc {
         desc


### PR DESCRIPTION
Before this fix, an update would fail:

```shell
$ brewer update
Updating the database, this will take some time
==> invalid type: null, expected a string at line 381356 column 22
```